### PR TITLE
Limit scope of installed items to /home/minecraft

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -166,7 +166,7 @@ function install_msm() {
     update_system_packages
     install_dependencies
     create_msm_directories
-    download_latest_files
+    #download_latest_files
     patch_latest_files
     install_config
     install_cron

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -1,4 +1,4 @@
-msm_dir="/opt/msm"
+msm_dir="/home/minecraft/msm"
 msm_user="minecraft"
 msm_user_system=false
 dl_dir="$(mktemp -d -t msm-XXX)"

--- a/installers/redhat.sh
+++ b/installers/redhat.sh
@@ -1,6 +1,4 @@
-UPDATE_URL="https://raw.githubusercontent.com/msmhq/msm/master"
-wget -q ${UPDATE_URL}/installers/common.sh -O /tmp/msmcommon.sh
-source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
+source msmcommon.sh
 
 function update_system_packages() {
     install_log "Updating sources"


### PR DESCRIPTION
This way it's easy to find everything related to minecraft servers on the shared-purpose server running Minecraft